### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main, master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/carsaimz/carsailms/security/code-scanning/4](https://github.com/carsaimz/carsailms/security/code-scanning/4)

To fix this, add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted to only what this pipeline needs. The best minimal fix without changing behavior is to set workflow-level permissions to:

- `contents: read` (needed by `actions/checkout` to read repo contents)

Given the shown steps, no additional write scopes are required. `actions/upload-artifact` uploads to the Actions artifact service and does not require repository write permissions like `contents: write`.

**File to change:** `.github/workflows/android.yml`  
**Region:** after the `on:` block (before `jobs:`) is the cleanest place to apply to all jobs.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
